### PR TITLE
fixed stack bugs to make the top k work for test in findKBest

### DIFF
--- a/src/main/java/fasttext/FastText.java
+++ b/src/main/java/fasttext/FastText.java
@@ -242,10 +242,8 @@ public class FastText {
 		if (words.isEmpty()) {
 			return;
 		}
-		Vector hidden = new Vector(args_.dim);
-		Vector output = new Vector(dict_.nlabels());
 		List<Pair<Float, Integer>> modelPredictions = new ArrayList<Pair<Float, Integer>>(k + 1);
-		model_.predict(words, k, modelPredictions, hidden, output);
+		model_.predict(words, k, modelPredictions);
 		predictions.clear();
 		for (Pair<Float, Integer> pair : modelPredictions) {
 			predictions.add(new Pair<Float, String>(pair.getKey(), dict_.getLabel(pair.getValue())));

--- a/src/main/java/fasttext/Model.java
+++ b/src/main/java/fasttext/Model.java
@@ -174,10 +174,11 @@ public class Model {
 	public void findKBest(int k, List<Pair<Float, Integer>> heap, Vector hidden, Vector output) {
 		computeOutputSoftmax(hidden, output);
 		for (int i = 0; i < osz_; i++) {
-			if (heap.size() == k && log(output.get(i)) < heap.get(0).getKey()) {
+			if (heap.size() == k && log(output.get(i)) < heap.get(heap.size() - 1).getKey()) {
 				continue;
 			}
 			heap.add(new Pair<Float, Integer>(log(output.get(i)), i));
+			Collections.sort(heap, comparePairs);
 			if (heap.size() > k) {
 				Collections.sort(heap, comparePairs);
 				heap.remove(heap.size() - 1); // pop last


### PR DESCRIPTION
this is a fix for issue #10 when k is > 1 , the Recall is lower than it is for the C version of fastText

the problem identified is that the stack used to store top k candidates
was not entirely and properly sorted.